### PR TITLE
Rewrite emitter to allow emitting events from within eventlisteners in non async mode

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -5,96 +5,83 @@ import (
 )
 
 type Emitter struct {
+	sync.RWMutex
+
 	async         bool
 	capturers     []*Capturer
 	listeners     map[EventType][]*Listener
-	listenerMutex sync.Mutex
+	listenersOnce map[EventType][]*Listener
 }
 
 // NewEmitter creates a new event emitter that implements the Observable interface.
 // Async determines whether events listeners fire in separate goroutines or not.
 func NewEmitter(async bool) (em *Emitter) {
 	em = &Emitter{
-		async:     async,
-		listeners: make(map[EventType][]*Listener),
+		async:         async,
+		listeners:     make(map[EventType][]*Listener),
+		listenersOnce: make(map[EventType][]*Listener),
 	}
 	return em
 }
 
 // EmitEvent emits the given event to all listeners and capturers
 func (em *Emitter) EmitEvent(event EventType, arguments ...interface{}) {
+	// If we have no single listeners for this event, skip
+	if len(em.listenersOnce) > 0 {
+		// Get a full lock, we are changing a map
+		em.Lock()
+		// Copy the slice
+		listenersOnce := em.listenersOnce[event]
+		// Create new empty slice
+		em.listenersOnce[event] = make([]*Listener, 0)
+		em.Unlock()
+
+		// No lock needed, we are working with an inaccessible copy
+		em.emitListenerEvents(listenersOnce, arguments)
+	}
+
 	// If we have no listeners for this event, skip
 	if len(em.listeners[event]) > 0 {
-		em.listenerMutex.Lock()
-		// Create a handlers slice copy to store the handlers we have to call outside the lock
-		handlers := make([]HandleFunc, len(em.listeners[event]))
-
-		removed := 0
-		var adjustedIndex int
-
-		for index := range em.listeners[event] {
-			adjustedIndex = index - removed
-
-			handlers[index] = em.listeners[event][adjustedIndex].handler
-
-			if em.listeners[event][adjustedIndex].once {
-				em.removeListenerAtIndex(event, adjustedIndex)
-				removed++
-			}
-		}
-		em.listenerMutex.Unlock()
-
-		// Call each handler outside the lock, so that these in turn can emit events if needed
-		for _, handler := range handlers {
-			if em.async {
-				go handler(arguments...)
-				continue
-			}
-			handler(arguments...)
-		}
+		em.RLock()
+		em.emitListenerEvents(em.listeners[event], arguments)
+		em.RUnlock()
 	}
 
-	// If we have no capturers, stop now
-	if len(em.capturers) == 0 {
-		return
+	// If we have no capturers, skip
+	if len(em.capturers) > 0 {
+		em.RLock()
+		em.emitCapturerEvents(em.capturers, event, arguments)
+		em.RUnlock()
 	}
+}
 
-	em.listenerMutex.Lock()
-	// Create a capturers slice copy to store the capturers we have to call outside the lock
-	capturers := make([]CaptureFunc, len(em.capturers))
-
-	removed := 0
-	var adjustedIndex int
-
-	for index := range em.capturers {
-		adjustedIndex = index - removed
-
-		capturers[index] = em.capturers[adjustedIndex].handler
-		if em.capturers[adjustedIndex].once {
-			em.removeCapturerAtIndex(adjustedIndex)
-			removed++
-		}
-	}
-	em.listenerMutex.Unlock()
-
-	// Call each capturer outside the lock, so that these in turn can emit events if needed
-	for _, capturer := range capturers {
+func (em *Emitter) emitListenerEvents(listeners []*Listener, arguments []interface{}) {
+	for _, listener := range listeners {
 		if em.async {
-			go capturer(event, arguments...)
+			go listener.handler(arguments...)
 			continue
 		}
-		capturer(event, arguments...)
+		listener.handler(arguments...)
+	}
+}
+
+func (em *Emitter) emitCapturerEvents(capturers []*Capturer, event EventType, arguments []interface{}) {
+	for _, capturer := range capturers {
+		if em.async {
+			go capturer.handler(event, arguments...)
+			continue
+		}
+		capturer.handler(event, arguments...)
 	}
 }
 
 // AddListener adds a listener for the given event type
 func (em *Emitter) AddListener(event EventType, handler HandleFunc) (listener *Listener) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	listener = &Listener{
 		handler: handler,
-		once:    false,
 	}
 	em.listeners[event] = append(em.listeners[event], listener)
 	return listener
@@ -102,38 +89,23 @@ func (em *Emitter) AddListener(event EventType, handler HandleFunc) (listener *L
 
 // ListenOnce adds a listener for the given event type that removes itself after it has been fired once
 func (em *Emitter) ListenOnce(event EventType, handler HandleFunc) (listener *Listener) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	listener = &Listener{
 		handler: handler,
-		once:    true,
 	}
-	em.listeners[event] = append(em.listeners[event], listener)
+	em.listenersOnce[event] = append(em.listenersOnce[event], listener)
 	return listener
 }
 
 // AddCapturer adds an event capturer for all events
 func (em *Emitter) AddCapturer(handler CaptureFunc) (capturer *Capturer) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	capturer = &Capturer{
 		handler: handler,
-		once:    false,
-	}
-	em.capturers = append(em.capturers, capturer)
-	return capturer
-}
-
-// CaptureOnce adds an event capturer for all events that removes itself after it has been fired once
-func (em *Emitter) CaptureOnce(handler CaptureFunc) (capturer *Capturer) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
-
-	capturer = &Capturer{
-		handler: handler,
-		once:    true,
 	}
 	em.capturers = append(em.capturers, capturer)
 	return capturer
@@ -141,12 +113,20 @@ func (em *Emitter) CaptureOnce(handler CaptureFunc) (capturer *Capturer) {
 
 // RemoveListener removes the registered given listener for the given event
 func (em *Emitter) RemoveListener(event EventType, listener *Listener) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	for index, list := range em.listeners[event] {
 		if list == listener {
-			em.removeListenerAtIndex(event, index)
+			em.removeListenerAt(event, index)
+			return
+		}
+	}
+
+	// If it hasnt been found yet, remove from listeners once if present there
+	for index, list := range em.listenersOnce[event] {
+		if list == listener {
+			em.removeOnceListenerAt(event, index)
 			return
 		}
 	}
@@ -154,28 +134,29 @@ func (em *Emitter) RemoveListener(event EventType, listener *Listener) {
 
 // RemoveAllListenersForEvent removes all registered listeners for a given event type
 func (em *Emitter) RemoveAllListenersForEvent(event EventType) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	em.listeners[event] = make([]*Listener, 0)
 }
 
 // RemoveAllListeners removes all registered listeners for all event types
 func (em *Emitter) RemoveAllListeners() {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	em.listeners = make(map[EventType][]*Listener)
+	em.listenersOnce = make(map[EventType][]*Listener)
 }
 
 // RemoveCapturer removes the given capturer
 func (em *Emitter) RemoveCapturer(capturer *Capturer) {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	for index, capt := range em.capturers {
 		if capt == capturer {
-			em.removeCapturerAtIndex(index)
+			em.removeCapturerAt(index)
 			return
 		}
 	}
@@ -183,19 +164,25 @@ func (em *Emitter) RemoveCapturer(capturer *Capturer) {
 
 // RemoveAllCapturers removes all registered capturers
 func (em *Emitter) RemoveAllCapturers() {
-	em.listenerMutex.Lock()
-	defer em.listenerMutex.Unlock()
+	em.Lock()
+	defer em.Unlock()
 
 	em.capturers = make([]*Capturer, 0)
 }
 
-func (em *Emitter) removeListenerAtIndex(event EventType, index int) {
+func (em *Emitter) removeListenerAt(event EventType, index int) {
 	copy(em.listeners[event][index:], em.listeners[event][index+1:])
 	em.listeners[event][len(em.listeners[event])-1] = nil
 	em.listeners[event] = em.listeners[event][:len(em.listeners[event])-1]
 }
 
-func (em *Emitter) removeCapturerAtIndex(index int) {
+func (em *Emitter) removeOnceListenerAt(event EventType, index int) {
+	copy(em.listenersOnce[event][index:], em.listenersOnce[event][index+1:])
+	em.listenersOnce[event][len(em.listenersOnce[event])-1] = nil
+	em.listenersOnce[event] = em.listenersOnce[event][:len(em.listenersOnce[event])-1]
+}
+
+func (em *Emitter) removeCapturerAt(index int) {
 	copy(em.capturers[index:], em.capturers[index+1:])
 	em.capturers[len(em.capturers)-1] = nil
 	em.capturers = em.capturers[:len(em.capturers)-1]

--- a/interface.go
+++ b/interface.go
@@ -2,16 +2,18 @@ package eventemitter
 
 type EventType string
 
+// HandleFunc is a handler function for a given event type
 type HandleFunc func(arguments ...interface{})
+// Listener is a container struct used to remove the listener
 type Listener struct {
 	handler HandleFunc
-	once    bool
 }
 
-type CaptureFunc func(eventName EventType, arguments ...interface{})
+// CaptureFunc is a capturer function that can capture all emitted events
+type CaptureFunc func(event EventType, arguments ...interface{})
+// Capturer is a container struct used to remove the capturer
 type Capturer struct {
 	handler CaptureFunc
-	once    bool
 }
 
 // Observable describes an object that can be listened to by event listeners and capturers
@@ -22,11 +24,9 @@ type Observable interface {
 	ListenOnce(event EventType, handler HandleFunc) (listener *Listener)
 	// AddCapturer adds an event capturer for all events
 	AddCapturer(handler CaptureFunc) (capturer *Capturer)
-	// CaptureOnce adds an event capturer for all events that removes itself after it has been fired once
-	CaptureOnce(handler CaptureFunc) (capturer *Capturer)
 	// RemoveListener removes the registered given listener for the given event
 	RemoveListener(event EventType, listener *Listener)
-	// // RemoveCapturer removes the given capturer
+	// RemoveCapturer removes the given capturer
 	RemoveCapturer(capturer *Capturer)
 }
 


### PR DESCRIPTION
Drops support for CaptureOnce() which is a weird feature anyway.